### PR TITLE
Change item to tile typo?

### DIFF
--- a/standard/clause_7_tile_core.adoc
+++ b/standard/clause_7_tile_core.adoc
@@ -143,7 +143,7 @@ include::requirements/tiles/core/REQ_sct-tmxslink.adoc[]
     ...
     {
      "href": "http://data.example.com/collections/buildings/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}.png",
-     "rel": "item",
+     "rel": "tile",
      "type": "image/png",
    }
    ...


### PR DESCRIPTION
Perhaps this isn't a typo, but in the tiles link response it seems like the 'rel' should be 'tile' instead of 'item'. Or if I'm wrong here it'd be good to have a bit more explanation.